### PR TITLE
Strava dates are now like 'May 22, 2010, 7:39:29 PM'

### DIFF
--- a/rename_activities.py
+++ b/rename_activities.py
@@ -3,6 +3,7 @@
 
 import argparse
 import csv
+import datetime
 import os
 import pathlib  # Python 3.4+
 import sys
@@ -23,14 +24,15 @@ def load_csv(csv_file):
     return data
 
 
-def convert_date_string(input):
-    # 2010-05-22 19:39:29
+def convert_date_string(input_string):
+    # May 22, 2010, 7:39:29 PM
     # ->
     # 20100522-193929
-    new_date = input
+    new_date = datetime.datetime.strptime(input_string, "%b %d, %Y, %I:%M:%S %p")
+    new_date = new_date.isoformat()
     new_date = new_date.replace("-", "")
     new_date = new_date.replace(":", "")
-    new_date = new_date.replace(" ", "-")
+    new_date = new_date.replace("T", "-")
     return new_date
 
 
@@ -48,7 +50,8 @@ def output_file(activity, ext=None):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="TODO", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description="Rename files, eg. 1836025202.gpx to 20180912-064451-Ride.gpx",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("-c", "--csv", default="activities.csv", help="CSV filename")
     parser.add_argument(


### PR DESCRIPTION
An export from 24th June has this:

```csv
id,date,name,type,description,elapsed_time,distance,commute,gear,filename
1836776031,2018-09-12 15:02:23,Evening Ride,Ride,,783,3681.0,true,Merida,activities/1836776031.gpx
```

And an export from today has this:

```csv
Activity ID,Activity Date,Activity Name,Activity Type,Activity Description,Elapsed Time,Distance,Commute,Activity Gear,Filename
1836776031,"Sep 12, 2018, 3:02:23 PM",Evening Ride,Ride,,783,3.68,true,Merida,activities/1836776031.gpx
```

The column headers were fixed in #1, this fixes the date format change. (Not relevant here, they also changed distance from m to km.)


# Before PR

```console
$ python3 rename_activities.py --dry-run

1208 rows found
activities/83514080.gpx.gz	->	activities/May-22,-2010,-73929-PM-Ride.gpx.gz
...
```

# With PR


```console
$ python3 rename_activities.py --dry-run

1208 rows found
activities/83514080.gpx.gz	->	activities/20100522-193929-Ride.gpx.gz
...
```