### PR TITLE
Replace 3.9-dev with 3.9 in CI to use python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
  - "3.6"
  - "3.7"
  - "3.8"
- - "3.9-dev"
+ - "3.9"
 
 install:
  - pip install -U pip


### PR DESCRIPTION
because this repository was mentioned here:
https://github.com/hugovk/pypistats/issues/181