### PR TITLE
splitter: Show error when cannot parse GPX file and continue

### DIFF
--- a/splitter.py
+++ b/splitter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import gpxpy  # pip3 install gpxpy
 import gpxpy.gpx
 from gpxpy.geo import ONE_DEGREE
-from termcolor import colored  # pip3 install termcolor
+from termcolor import cprint  # pip3 install termcolor
 from tqdm import tqdm  # pip3 install tqdm
 
 # from pprint import pprint
@@ -85,12 +85,17 @@ def save_gpx(gpx, filename, dry_run):
         with open(new_filename, "w") as f:
             f.write(gpx.to_xml())
 
-    print(colored(new_filename, "green"))
+    cprint(new_filename, "green")
 
 
 def split_gpx(filename, max_distance, max2, dry_run):
     gpx_file = open(filename)
-    gpx = gpxpy.parse(gpx_file)
+    try:
+        gpx = gpxpy.parse(gpx_file)
+    except gpxpy.gpx.GPXException as e:
+        print(gpx_file)
+        cprint(f"Cannot parse {filename}: {e}", "red")
+        return
 
     new_gpx = copy.deepcopy(gpx)
     new_gpx.tracks = []


### PR DESCRIPTION
There's a problem with one file:
```console
$ python splitter.py -i activities/20190831-090236-Ride.gpx
Namespace(inspec='activities/20190831-090236-Ride.gpx', max=4000, dry_run=False)
1 found
  0%|                                                                                                                              | 0/1 [00:00<?, ?gpx/s]multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/hugo/github/strava-tools/splitter.py", line 93, in split_gpx
    gpx = gpxpy.parse(gpx_file)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/__init__.py", line 39, in parse
    return parser.parse(version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/parser.py", line 154, in parse
    mod_gpxfield.gpx_fields_from_xml(self.gpx, root, version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 590, in gpx_fields_from_xml
    value = gpx_field.from_xml(current_node, version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 241, in from_xml
    result.append(gpx_fields_from_xml(self.classs, child,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 590, in gpx_fields_from_xml
    value = gpx_field.from_xml(current_node, version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 241, in from_xml
    result.append(gpx_fields_from_xml(self.classs, child,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 590, in gpx_fields_from_xml
    value = gpx_field.from_xml(current_node, version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 241, in from_xml
    result.append(gpx_fields_from_xml(self.classs, child,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 590, in gpx_fields_from_xml
    value = gpx_field.from_xml(current_node, version)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/gpxpy/gpxfield.py", line 197, in from_xml
    raise mod_gpx.GPXException(f'{self.name} is mandatory in {self.tag} (got {result})')
gpxpy.gpx.GPXException: latitude is mandatory in None (got None)
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/hugo/github/strava-tools/splitter.py", line 200, in <module>
    r.get()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/pool.py", line 771, in get
    raise self._value
gpxpy.gpx.GPXException: latitude is mandatory in None (got None)
  0%|                                                                                                                              | 0/1 [00:00<?, ?gpx/s]
```

For some reason, this GPX file is missing required `lon` and `lat` values from the first `<trkpt>`:


```xml
<?xml version="1.0" encoding="UTF-8"?>
<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" creator="Wahoo ELEMNT BOLT" version="5.8">
  <metadata>
    <link href="https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php">
      <text>GOTOES STRAVA TOOLS</text>
    </link>
    <time>2019-08-31T09:02:36Z</time>
  </metadata>
  <trk>
    <type>Other</type>
    <trkseg>
      <trkpt>
        <ele>31.2</ele>
        <time>2019-08-31T09:02:36Z</time>
        <extensions>
          <gpxdata:temp>0</gpxdata:temp>
        </extensions>
      </trkpt>
      <trkpt lon="24.83604" lat="60.34266">
        <ele>31.2</ele>
        <time>2019-08-31T09:02:37Z</time>
        <extensions>
          <gpxdata:temp>29</gpxdata:temp>
        </extensions>
      </trkpt>
      <trkpt lon="24.83604" lat="60.34266">
        <ele>31.2</ele>
        <time>2019-08-31T09:02:38Z</time>
        <extensions>
          <gpxdata:temp>29</gpxdata:temp>
        </extensions>
      </trkpt>
```

This particular file won't get split anyway, let's print out in red if files cannot be parsed and continue with the rest.

(For reference, it's https://www.strava.com/activities/2672495924, which did have some editing with the GOTOES Strava Tools at some point.)